### PR TITLE
Render-Spec

### DIFF
--- a/src/_config.py
+++ b/src/_config.py
@@ -41,6 +41,9 @@ class AppConfig:
         self.output_file_name = self.file.get(
             section='APP.FILES', option='Output.File.Name',
             fallback='#name (#frame<, #suffix>) [#set] {#num}')
+        self.maintain_folder_structure = self.file.getboolean(
+            section='APP.FILES', option='Maintain.Folder.Structure',
+            fallback=True)
 
         # APP - DATA
         self.lang = self.file.get('APP.DATA', 'Scryfall.Language', fallback='en')

--- a/src/data/config/app.toml
+++ b/src/data/config/app.toml
@@ -22,6 +22,12 @@ desc = """Choose how the rendered card images are named. See the README for adva
 type = "string"
 default = "#name (#frame<, #suffix>) [#set] {#num}"
 
+[FILES."Maintain.Folder.Structure"]
+title = "Maintain Folder Structure"
+desc = """Choose whether to flatten all images into the `out` folder or maintain the folder structure of the `art` folder."""
+type = "bool"
+default = 1
+
 [FILES."Overwrite.Duplicate"]
 title = "Overwrite Duplicates"
 desc = """Overwrite rendered files with identical file names."""

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -58,6 +58,7 @@ from src.gui.test import TestApp
 from src.layouts import (
     layout_map,
     assign_layout,
+    flatten_cards,
     join_dual_card_layouts,
     NormalLayout)
 from src.templates import BaseTemplate
@@ -426,8 +427,11 @@ class ProxyshopGUIApp(App):
         with ThreadPoolExecutor(max_workers=cpu_count()) as pool:
             cards = pool.map(assign_layout, files)
 
+            # Flatten results, which may contain lists
+            cards = flatten_cards(list(cards))
+
         # Join dual card layouts
-        cards = join_dual_card_layouts(list(cards))
+        cards = join_dual_card_layouts(cards)
 
         # Remove failed strings
         layouts: dict[str, dict[str, list[NormalLayout]]] = {}

--- a/src/layouts.py
+++ b/src/layouts.py
@@ -414,6 +414,9 @@ class NormalLayout:
     @cached_property
     def symbol_code(self) -> str:
         """Code used to match a symbol to this card's set. Provided by hexproof.io."""
+        forced_symbol = self.file.get('additional_cfg', {}).get('sym', None)
+        if forced_symbol:
+            return forced_symbol.upper()
         if CFG.symbol_force_default:
             return CFG.symbol_default.upper()
         return self.set_data.get('code_symbol', 'DEFAULT').upper()

--- a/src/layouts.py
+++ b/src/layouts.py
@@ -15,6 +15,7 @@ from omnitils.strings import get_line, get_lines, normalize_str, strip_lines
 # Local Imports
 from src import CFG, CON, CONSOLE, ENV, PATH
 from src.cards import CardDetails, FrameDetails, get_card_data, parse_card_info, process_card_data
+from src.render_spec import parse_render_spec
 from src.console import msg_error, msg_success
 from src.utils.hexapi import get_watermark_svg, get_watermark_svg_from_set
 from src.utils.scryfall import get_cards_oracle
@@ -47,11 +48,11 @@ class PowerToughness(TypedDict):
 """
 
 
-def assign_layout(filename: Path) -> str | ForwardRef('CardLayout'):
-    """Assign layout object to a card.
+def assign_layout(filename: Path) -> str | ForwardRef('CardLayout') | list[ForwardRef('CardLayout')]:
+    """Assign layout objects to a input file.
 
     Args:
-        filename (Path): Path to the art file, filename supports optional tags.
+        filename (Path): Path to the art file or render spec, filename supports optional tags.
 
     Filename Tags:
         | Tag        | Description                                                   |
@@ -60,33 +61,69 @@ def assign_layout(filename: Path) -> str | ForwardRef('CardLayout'):
         | `[set]`    | Uses a specific set printing when fetching Scryfall data.     |
         | `{number}` | Uses a specific collector number when fetching Scryfall data. |
         | `$creator` | Must be at the end of filename, indicates the creator.        |
+        | `[k=v]`    | Arbitrary key-value pairs that a frame may or may not use.    |
 
     Returns:
-        str | CardLayout: Layout object for this card.
+        str | CardLayout | list[CardLayout]: Layout objects for this file (single object if it's a card, list of objects if it's a render spec).
     """
-    # Get basic card information
-    card = parse_card_info(filename)
-    name_failed = osp.basename(str(card.get('file', 'None')))
 
-    # Get scryfall data for the card
-    scryfall = get_card_data(card, cfg=CFG, logger=CONSOLE)
-    if not scryfall:
-        return msg_error(name_failed, reason="Scryfall search failed")
-    scryfall = process_card_data(scryfall, card)
+    if Path(filename).suffix == ".txt":
+        # .txt files declare a render spec, open and unwrap these seperately
+        spec = parse_render_spec(filename)
+        cards = spec['cards']
+    else:
+        # Otherwise it's a regular old card ...
+        # Get basic card information
+        cards = [parse_card_info(filename)]
 
-    # Instantiate layout object
-    if scryfall.get('layout', 'None') in layout_map:
-        try:
-            layout = layout_map[scryfall['layout']](scryfall, card)
-        except Exception as e:
-            # Couldn't instantiate layout object
-            CONSOLE.log_exception(e)
-            return msg_error(name_failed, reason="Layout generation failed")
-        if not ENV.TEST_MODE:
-            CONSOLE.update(f"{msg_success('FOUND:')} {str(layout)}")
-        return layout
-    # Couldn't find an appropriate layout
-    return msg_error(name_failed, reason="Layout incompatible")
+    def assign_layout_impl(card):
+        name_failed = osp.basename(str(card.get('file', 'None')))
+
+        # Get scryfall data for the card
+        scryfall = get_card_data(card, cfg=CFG, logger=CONSOLE)
+        if not scryfall:
+            return msg_error(name_failed, reason="Scryfall search failed")
+        scryfall = process_card_data(scryfall, card)
+
+        # Instantiate layout object
+        if scryfall.get('layout', 'None') in layout_map:
+            try:
+                layout = layout_map[scryfall['layout']](scryfall, card)
+            except Exception as e:
+                # Couldn't instantiate layout object
+                CONSOLE.log_exception(e)
+                return msg_error(name_failed, reason="Layout generation failed")
+            if not ENV.TEST_MODE:
+                CONSOLE.update(f"{msg_success('FOUND:')} {str(layout)}")
+            return layout
+
+        # Couldn't find an appropriate layout
+        return msg_error(name_failed, reason="Layout incompatible")
+    
+    # Assign layouts and return
+    layouts = list(map(assign_layout_impl, cards))
+    if len(layouts) == 1:
+        return layouts[0]
+    return layouts
+
+
+def flatten_cards(cards: list[Union[str, 'CardLayout', list['CardLayout']]]) -> list[str, 'CardLayout']:
+    """Utility that flattens a list of return values from assign_layout into a list of cards.
+    
+    Args:
+        cards: A list of values returned from assign_layout
+    
+    Returns:
+        A list of layout objects
+    """
+
+    def flatten_impl(list_or_obj):
+        if isinstance(list_or_obj, list):
+            return [nested_element for element in list_or_obj for nested_element in flatten_impl(element)]
+        else:
+            return [list_or_obj]
+
+    return flatten_impl(cards)
 
 
 def join_dual_card_layouts(layouts: list[Union[str, 'CardLayout']]):

--- a/src/render_spec.py
+++ b/src/render_spec.py
@@ -1,0 +1,98 @@
+"""
+* Render Spec Module
+* Handles parsing render spec file, aka text files that contain a set of configurations and cards to render
+"""
+
+# Standard Library Imports
+import re as regex
+from pathlib import Path
+from typing import Dict, TypedDict, Optional, Any
+
+# Local Imports
+from src.cards import CardDetails, parse_card_info
+
+"""
+* Types
+"""
+
+
+class RenderConfiguration(TypedDict):
+    name: str
+    info: str
+
+
+class RenderSpec(TypedDict):
+    """Render spec obtained from parsing the file."""
+
+    name: str
+    file: Path
+    configs: Dict[str, RenderConfiguration]
+    cards: list[CardDetails]
+
+
+"""
+* File parsing
+"""
+
+
+def parse_render_spec(file_path: Path, logger: Optional[Any] = None) -> RenderSpec:
+    """Retrieve render spec from the input file.
+
+    Args:
+        file_path: Path to the text file.
+        logger: Console or other logger object used to relay warning messages.
+
+    Returns:
+        Dict containing the configurations and cards in this spec.
+    """
+
+    # Extract just the spec name
+    file_name = file_path.stem
+
+    # Load all the content and get rid of empty lines and comments
+    spec_lines = open(file_path, "r").read().splitlines()
+    spec_lines = [l for l in spec_lines if l.split("#")[0].strip()]
+
+    # Split lines with configs and lines with cards
+    config_lines = [l for l in spec_lines if regex.match(r"([a-zA-Z0-9_ ]+):(.*)", l)]
+    card_lines = [l for l in spec_lines if l not in config_lines]
+
+    # Find all the configurations first
+    configs = {}
+    for l in config_lines:
+        [config_name, config_info] = map(str.strip, l.split(":"))
+        configs[config_name] = {
+            "name": config_name,
+            "info": config_info,
+        }
+
+    # Now find all the cards and parse them by using the configs
+    cards = []
+    for l in card_lines:
+        parts = list(map(str.strip, l.split("|")))
+        full_card_spec = parts[0]
+        used_configs = parts[1:]
+        invalid_configs = [c for c in used_configs if c not in configs]
+        if invalid_configs:
+            if logger:
+                logger.update(
+                    f"Card ignored due to unknown render spec configurations: {full_card_spec.split()[0]}"
+                )
+                for c in invalid_configs:
+                    logger.update(f"\nUnknown render spec configuration: {c}")
+            continue
+        for c in used_configs:
+            spec_info = configs[c]["info"]
+            full_card_spec += f" {spec_info}"
+
+        # Pretend this is a file and parse that
+        full_card_path = file_path.with_name(full_card_spec)
+        cards.append(parse_card_info(full_card_path))
+
+    # Return dictionary
+    return {
+        "name": file_name,
+        "file": file_path,
+        "configs": configs,
+        "cards": cards,
+    }

--- a/src/render_spec.py
+++ b/src/render_spec.py
@@ -5,10 +5,11 @@
 
 # Standard Library Imports
 import os
+import re
 import glob
 import re as regex
 from pathlib import Path
-from typing import Dict, TypedDict, Optional, Any
+from typing import Dict, TypedDict
 
 # Local Imports
 from src.cards import CardDetails, parse_card_info
@@ -88,6 +89,11 @@ def parse_render_spec(file_path: Path) -> RenderSpec:
 
         def append_card(card_spec):
             spec, path = card_spec
+            # Make sure the extension doesn't contain a ']' as that implies
+            # we have something without extension using a config that contains
+            # something with extension, e.g. [art=file.png]
+            if not re.match(r"\.[^\]]+$", spec):
+                spec += ".png"
             # Pretend this is a file right next to the spec and parse that
             full_card_path = file_path.parent / Path(spec).name
             card_info = parse_card_info(full_card_path)
@@ -119,14 +125,17 @@ def parse_render_spec(file_path: Path) -> RenderSpec:
                 ended_group = groups.pop()
                 ended_group = [append_config(c, group_spec) for c in ended_group]
 
+                def expand_variable(card, variable, value):
+                    return (card[0].replace(variable, str(value)), card[1])
+
                 if groups:
                     # Replace special variables
                     ended_group = [
-                        c.replace("${GROUP_INDEX}", str(i))
+                        expand_variable(c, "${GROUP_INDEX}", i)
                         for (i, c) in enumerate(ended_group)
                     ]
                     ended_group = [
-                        c.replace("${INNER_GROUP_INDEX}", str(i))
+                        expand_variable(c, "${INNER_GROUP_INDEX}", i)
                         for (i, c) in enumerate(ended_group)
                     ]
 
@@ -135,11 +144,11 @@ def parse_render_spec(file_path: Path) -> RenderSpec:
                 else:
                     # Replace special variables
                     ended_group = [
-                        c.replace("${GROUP_INDEX}", str(i))
+                        expand_variable(c, "${GROUP_INDEX}", i)
                         for (i, c) in enumerate(ended_group)
                     ]
                     ended_group = [
-                        c.replace("${OUTER_GROUP_INDEX}", str(i))
+                        expand_variable(c, "${OUTER_GROUP_INDEX}", i)
                         for (i, c) in enumerate(ended_group)
                     ]
 

--- a/src/render_spec.py
+++ b/src/render_spec.py
@@ -4,6 +4,7 @@
 """
 
 # Standard Library Imports
+import os
 import glob
 import re as regex
 from pathlib import Path
@@ -82,11 +83,25 @@ def parse_render_spec(file_path: Path) -> RenderSpec:
         parts = list(map(str.strip, l.split("|")))
         spec_base = parts[0]
 
+        def append_config(card, config):
+            return (card[0] + f" {config}", card[1])
+
+        def append_card(card_spec):
+            spec, path = card_spec
+            # Pretend this is a file and parse that
+            full_card_path = file_path.parent.joinpath(spec)
+            card_info = parse_card_info(full_card_path)
+            if path is not None:
+                card_info["additional_cfg"]["art"] = path
+            cards.append(card_info)
+
         if "*" in spec_base:
             specs = glob.glob(spec_base, root_dir=parent_dir, recursive=True)
-            specs = [s for s in specs if not s.endswith(".txt")]
+            specs = [(s.split(".")[0], s) for s in specs if not s.endswith(".txt")]
+        elif os.path.exists(spec_base):
+            specs = [(spec_base.split(".")[0], spec_base)]
         else:
-            specs = [spec_base]
+            specs = [(spec_base, None)]
 
         used_configs = parts[1:]
         for c in used_configs:
@@ -94,20 +109,15 @@ def parse_render_spec(file_path: Path) -> RenderSpec:
                 config_spec = configs[c]["info"]
             else:
                 config_spec = c
-            specs = [s + f" {config_spec}" for s in specs]
-
-        def append_card(card_spec):
-            # Pretend this is a file and parse that
-            full_card_path = file_path.parent.joinpath(card_spec)
-            cards.append(parse_card_info(full_card_path))
+            specs = [append_config(s, config_spec) for s in specs]
 
         # If part of a group we need to just accumulate
         if groups:
             if l.startswith("}"):
                 # The group ended, so we assign this configuration to all the cards in it
-                group_spec = specs[0][1:].strip()
+                group_spec = specs[0][0][1:].strip()
                 ended_group = groups.pop()
-                ended_group = [c + f" {group_spec}" for c in ended_group]
+                ended_group = [append_config(c, group_spec) for c in ended_group]
 
                 if groups:
                     # Replace special variables

--- a/src/render_spec.py
+++ b/src/render_spec.py
@@ -4,6 +4,7 @@
 """
 
 # Standard Library Imports
+import glob
 import re as regex
 from pathlib import Path
 from typing import Dict, TypedDict, Optional, Any
@@ -47,6 +48,7 @@ def parse_render_spec(file_path: Path) -> RenderSpec:
 
     # Extract just the spec name
     file_name = file_path.stem
+    parent_dir = str(file_path.parent)
 
     # Load all the content and get rid of empty lines and comments
     spec_lines = open(file_path, "r").read().splitlines()
@@ -78,27 +80,34 @@ def parse_render_spec(file_path: Path) -> RenderSpec:
                 continue
 
         parts = list(map(str.strip, l.split("|")))
-        full_line_spec = parts[0]
+        spec_base = parts[0]
+
+        if "*" in spec_base:
+            specs = glob.glob(spec_base, root_dir=parent_dir, recursive=True)
+            specs = [s for s in specs if not s.endswith(".txt")]
+        else:
+            specs = [spec_base]
+
         used_configs = parts[1:]
         for c in used_configs:
             if c in configs:
-                spec_info = configs[c]["info"]
-                full_line_spec += f" {spec_info}"
+                config_spec = configs[c]["info"]
             else:
-                full_line_spec += f" {c}"
+                config_spec = c
+            specs = [s + f" {config_spec}" for s in specs]
 
         def append_card(card_spec):
             # Pretend this is a file and parse that
-            full_card_path = file_path.with_stem(card_spec)
+            full_card_path = file_path.parent.joinpath(card_spec)
             cards.append(parse_card_info(full_card_path))
 
         # If part of a group we need to just accumulate
         if groups:
             if l.startswith("}"):
                 # The group ended, so we assign this configuration to all the cards in it
-                full_line_spec = full_line_spec[1:].strip()
+                group_spec = specs[0][1:].strip()
                 ended_group = groups.pop()
-                ended_group = [c + f" {full_line_spec}" for c in ended_group]
+                ended_group = [c + f" {group_spec}" for c in ended_group]
 
                 if groups:
                     # Replace special variables
@@ -129,9 +138,10 @@ def parse_render_spec(file_path: Path) -> RenderSpec:
                         append_card(card)
             else:
                 # Append the card to the group
-                groups[-1].append(full_line_spec)
+                groups[-1].extend(specs)
         else:
-            append_card(full_line_spec)
+            for card_spec in specs:
+                append_card(card_spec)
 
     # Return dictionary
     return {

--- a/src/render_spec.py
+++ b/src/render_spec.py
@@ -68,26 +68,62 @@ def parse_render_spec(file_path: Path, logger: Optional[Any] = None) -> RenderSp
 
     # Now find all the cards and parse them by using the configs
     cards = []
+    groups = []
     for l in card_lines:
+        # Entering a group
+        if l.startswith("{"):
+            groups.append([])
+            l = l[1:].strip()
+            if not l:
+                continue
+
         parts = list(map(str.strip, l.split("|")))
-        full_card_spec = parts[0]
+        full_line_spec = parts[0]
         used_configs = parts[1:]
         invalid_configs = [c for c in used_configs if c not in configs]
         if invalid_configs:
             if logger:
                 logger.update(
-                    f"Card ignored due to unknown render spec configurations: {full_card_spec.split()[0]}"
+                    f"Card ignored due to unknown render spec configurations: {full_line_spec.split()[0]}"
                 )
                 for c in invalid_configs:
                     logger.update(f"\nUnknown render spec configuration: {c}")
             continue
         for c in used_configs:
             spec_info = configs[c]["info"]
-            full_card_spec += f" {spec_info}"
+            full_line_spec += f" {spec_info}"
 
-        # Pretend this is a file and parse that
-        full_card_path = file_path.with_name(full_card_spec)
-        cards.append(parse_card_info(full_card_path))
+        def append_card(card_spec):
+            # Pretend this is a file and parse that
+            full_card_path = file_path.with_stem(card_spec)
+            cards.append(parse_card_info(full_card_path))
+
+        # If part of a group we need to just accumulate
+        if groups:
+            if l.startswith("}"):
+                # The group ended, so we assign this configuration to all the cards in it
+                full_line_spec = full_line_spec[1:].strip()
+                ended_group = groups.pop()
+                ended_group = [c + f" {full_line_spec}" for c in ended_group]
+
+                # Replace special variables
+                ended_group = [
+                    c.replace("${GROUP_INDEX}", str(i))
+                    for (i, c) in enumerate(ended_group)
+                ]
+
+                if groups:
+                    # If this was a nested group we just put these into the outer group
+                    groups[-1].extend(ended_group)
+                else:
+                    # Otherwise append to the render spec
+                    for card in ended_group:
+                        append_card(card)
+            else:
+                # Append the card to the group
+                groups[-1].append(full_line_spec)
+        else:
+            append_card(full_line_spec)
 
     # Return dictionary
     return {

--- a/src/render_spec.py
+++ b/src/render_spec.py
@@ -88,8 +88,8 @@ def parse_render_spec(file_path: Path) -> RenderSpec:
 
         def append_card(card_spec):
             spec, path = card_spec
-            # Pretend this is a file and parse that
-            full_card_path = file_path.parent.joinpath(spec)
+            # Pretend this is a file right next to the spec and parse that
+            full_card_path = file_path.parent / Path(spec).name
             card_info = parse_card_info(full_card_path)
             if path is not None:
                 card_info["additional_cfg"]["art"] = path

--- a/src/render_spec.py
+++ b/src/render_spec.py
@@ -35,12 +35,11 @@ class RenderSpec(TypedDict):
 """
 
 
-def parse_render_spec(file_path: Path, logger: Optional[Any] = None) -> RenderSpec:
+def parse_render_spec(file_path: Path) -> RenderSpec:
     """Retrieve render spec from the input file.
 
     Args:
         file_path: Path to the text file.
-        logger: Console or other logger object used to relay warning messages.
 
     Returns:
         Dict containing the configurations and cards in this spec.
@@ -51,7 +50,8 @@ def parse_render_spec(file_path: Path, logger: Optional[Any] = None) -> RenderSp
 
     # Load all the content and get rid of empty lines and comments
     spec_lines = open(file_path, "r").read().splitlines()
-    spec_lines = [l for l in spec_lines if l.split("#")[0].strip()]
+    spec_lines = [l.split("#")[0].strip() for l in spec_lines]
+    spec_lines = [l for l in spec_lines if l]
 
     # Split lines with configs and lines with cards
     config_lines = [l for l in spec_lines if regex.match(r"([a-zA-Z0-9_ ]+):(.*)", l)]
@@ -80,18 +80,12 @@ def parse_render_spec(file_path: Path, logger: Optional[Any] = None) -> RenderSp
         parts = list(map(str.strip, l.split("|")))
         full_line_spec = parts[0]
         used_configs = parts[1:]
-        invalid_configs = [c for c in used_configs if c not in configs]
-        if invalid_configs:
-            if logger:
-                logger.update(
-                    f"Card ignored due to unknown render spec configurations: {full_line_spec.split()[0]}"
-                )
-                for c in invalid_configs:
-                    logger.update(f"\nUnknown render spec configuration: {c}")
-            continue
         for c in used_configs:
-            spec_info = configs[c]["info"]
-            full_line_spec += f" {spec_info}"
+            if c in configs:
+                spec_info = configs[c]["info"]
+                full_line_spec += f" {spec_info}"
+            else:
+                full_line_spec += f" {c}"
 
         def append_card(card_spec):
             # Pretend this is a file and parse that

--- a/src/render_spec.py
+++ b/src/render_spec.py
@@ -97,7 +97,10 @@ def parse_render_spec(file_path: Path) -> RenderSpec:
         ) -> CardSpec:
             if isinstance(config, RenderConfiguration):
                 config = config.spec
-            return CardSpec(card.spec + f" {config}", card.actual_path)
+            return CardSpec(
+                card.spec + f" {config}",
+                card.actual_path,
+            )
 
         def append_card(card_spec: CardSpec):
             spec, path = astuple(card_spec)
@@ -138,8 +141,11 @@ def parse_render_spec(file_path: Path) -> RenderSpec:
                 ended_group = groups.pop()
                 ended_group = [append_config(c, group_spec) for c in ended_group]
 
-                def expand_variable(card, variable, value):
-                    return (card[0].replace(variable, str(value)), card[1])
+                def expand_variable(card: CardSpec, variable: str, value: str | int):
+                    return CardSpec(
+                        card.spec.replace(variable, str(value)),
+                        card.actual_path,
+                    )
 
                 if groups:
                     # Replace special variables

--- a/src/render_spec.py
+++ b/src/render_spec.py
@@ -10,6 +10,7 @@ import glob
 import re as regex
 from pathlib import Path
 from typing import Dict, TypedDict
+from dataclasses import dataclass, astuple
 
 # Local Imports
 from src.cards import CardDetails, parse_card_info
@@ -19,9 +20,16 @@ from src.cards import CardDetails, parse_card_info
 """
 
 
-class RenderConfiguration(TypedDict):
+@dataclass
+class RenderConfiguration:
     name: str
-    info: str
+    spec: str
+
+
+@dataclass
+class CardSpec:
+    spec: str
+    actual_path: str | None
 
 
 class RenderSpec(TypedDict):
@@ -64,11 +72,11 @@ def parse_render_spec(file_path: Path) -> RenderSpec:
     # Find all the configurations first
     configs = {}
     for l in config_lines:
-        [config_name, config_info] = map(str.strip, l.split(":"))
-        configs[config_name] = {
-            "name": config_name,
-            "info": config_info,
-        }
+        [config_name, config_spec] = map(str.strip, l.split(":"))
+        configs[config_name] = RenderConfiguration(
+            name=config_name,
+            spec=config_spec,
+        )
 
     # Now find all the cards and parse them by using the configs
     cards = []
@@ -84,11 +92,15 @@ def parse_render_spec(file_path: Path) -> RenderSpec:
         parts = list(map(str.strip, l.split("|")))
         spec_base = parts[0]
 
-        def append_config(card, config):
-            return (card[0] + f" {config}", card[1])
+        def append_config(
+            card: CardSpec, config: RenderConfiguration | str
+        ) -> CardSpec:
+            if isinstance(config, RenderConfiguration):
+                config = config.spec
+            return CardSpec(card.spec + f" {config}", card.actual_path)
 
-        def append_card(card_spec):
-            spec, path = card_spec
+        def append_card(card_spec: CardSpec):
+            spec, path = astuple(card_spec)
             # Make sure the extension doesn't contain a ']' as that implies
             # we have something without extension using a config that contains
             # something with extension, e.g. [art=file.png]
@@ -97,31 +109,32 @@ def parse_render_spec(file_path: Path) -> RenderSpec:
             # Pretend this is a file right next to the spec and parse that
             full_card_path = file_path.parent / Path(spec).name
             card_info = parse_card_info(full_card_path)
-            if path is not None:
+            if path is not None and "art" not in card_info["additional_cfg"]:
                 card_info["additional_cfg"]["art"] = path
             cards.append(card_info)
 
         if "*" in spec_base:
             specs = glob.glob(spec_base, root_dir=parent_dir, recursive=True)
-            specs = [(s.split(".")[0], s) for s in specs if not s.endswith(".txt")]
+            specs = [
+                CardSpec(s.split(".")[0], s) for s in specs if not s.endswith(".txt")
+            ]
         elif os.path.exists(spec_base):
-            specs = [(spec_base.split(".")[0], spec_base)]
+            specs = [CardSpec(spec_base.split(".")[0], spec_base)]
         else:
-            specs = [(spec_base, None)]
+            specs = [CardSpec(spec_base, None)]
 
         used_configs = parts[1:]
         for c in used_configs:
             if c in configs:
-                config_spec = configs[c]["info"]
+                specs = [append_config(s, configs[c]) for s in specs]
             else:
-                config_spec = c
-            specs = [append_config(s, config_spec) for s in specs]
+                specs = [append_config(s, c) for s in specs]
 
         # If part of a group we need to just accumulate
         if groups:
             if l.startswith("}"):
                 # The group ended, so we assign this configuration to all the cards in it
-                group_spec = specs[0][0][1:].strip()
+                group_spec = specs[0].spec[1:].strip()
                 ended_group = groups.pop()
                 ended_group = [append_config(c, group_spec) for c in ended_group]
 

--- a/src/render_spec.py
+++ b/src/render_spec.py
@@ -106,16 +106,30 @@ def parse_render_spec(file_path: Path, logger: Optional[Any] = None) -> RenderSp
                 ended_group = groups.pop()
                 ended_group = [c + f" {full_line_spec}" for c in ended_group]
 
-                # Replace special variables
-                ended_group = [
-                    c.replace("${GROUP_INDEX}", str(i))
-                    for (i, c) in enumerate(ended_group)
-                ]
-
                 if groups:
+                    # Replace special variables
+                    ended_group = [
+                        c.replace("${GROUP_INDEX}", str(i))
+                        for (i, c) in enumerate(ended_group)
+                    ]
+                    ended_group = [
+                        c.replace("${INNER_GROUP_INDEX}", str(i))
+                        for (i, c) in enumerate(ended_group)
+                    ]
+
                     # If this was a nested group we just put these into the outer group
                     groups[-1].extend(ended_group)
                 else:
+                    # Replace special variables
+                    ended_group = [
+                        c.replace("${GROUP_INDEX}", str(i))
+                        for (i, c) in enumerate(ended_group)
+                    ]
+                    ended_group = [
+                        c.replace("${OUTER_GROUP_INDEX}", str(i))
+                        for (i, c) in enumerate(ended_group)
+                    ]
+
                     # Otherwise append to the render spec
                     for card in ended_group:
                         append_card(card)

--- a/src/templates/_core.py
+++ b/src/templates/_core.py
@@ -2,6 +2,7 @@
 * CORE PROXYSHOP TEMPLATES
 """
 # Standard Library Imports
+import os
 import os.path as osp
 from contextlib import suppress
 from functools import cached_property
@@ -303,6 +304,10 @@ class BaseTemplate:
             self.output_directory,
             sanitize_filename(name)
         ).with_suffix(f'.{CFG.output_file_type}')
+
+        if CFG.maintain_folder_structure and self.art_file.is_relative_to(PATH.ART):
+            relative_path = self.art_file.parent.relative_to(PATH.ART)
+            path = path.parent / relative_path / path.name
 
         # Are we overwriting duplicate names?
         if not CFG.overwrite_duplicate:
@@ -1638,6 +1643,12 @@ class BaseTemplate:
         # Manual edit step?
         if CFG.exit_early and not ENV.TEST_MODE:
             self.console.await_choice(self.event)
+
+        # Make sure output folder exists
+        if CFG.maintain_folder_structure:
+            output_folder = self.output_file_name.parent
+            if not osp.exists(output_folder):
+                os.makedirs(output_folder)
 
         # Save the document
         if not self.run_tasks(

--- a/src/templates/_core.py
+++ b/src/templates/_core.py
@@ -755,7 +755,11 @@ class BaseTemplate:
         """Path to the art file to load."""
         art_file = self.layout.file.get('additional_cfg', {}).get('art', None)
         if art_file is not None:
-            return self.layout.art_file.with_name(art_file)
+            art_file = Path(art_file)
+            if art_file.is_absolute():
+                return art_file
+            else:
+                return self.layout.art_file.parent / art_file
         else:
             return self.layout.art_file
 

--- a/src/templates/_core.py
+++ b/src/templates/_core.py
@@ -755,7 +755,7 @@ class BaseTemplate:
     * Loading Artwork
     """
 
-    @auto_prop_cached
+    @cached_property
     def art_file(self) -> Path:
         """Path to the art file to load."""
         art_file = self.layout.file.get('additional_cfg', {}).get('art', None)

--- a/src/templates/_core.py
+++ b/src/templates/_core.py
@@ -443,7 +443,7 @@ class BaseTemplate:
     @cached_property
     def is_art_vertical(self) -> bool:
         """bool: Returns True if art provided is vertically oriented, False if it is horizontal."""
-        with Image.open(self.layout.art_file) as image:
+        with Image.open(self.art_file) as image:
             width, height = image.size
         if height > (width * 1.1):
             # Vertical orientation
@@ -750,6 +750,15 @@ class BaseTemplate:
     * Loading Artwork
     """
 
+    @auto_prop_cached
+    def art_file(self) -> Path:
+        """Path to the art file to load."""
+        art_file = self.layout.file.get('additional_cfg', {}).get('art', None)
+        if art_file is not None:
+            return self.layout.art_file.with_name(art_file)
+        else:
+            return self.layout.art_file
+
     @property
     def art_action(self) -> Optional[Callable]:
         """Function that is called to perform an action on the imported art."""
@@ -769,7 +778,7 @@ class BaseTemplate:
         """Loads the specified art file into the specified layer.
 
         Args:
-            art_file: Optional path (as str or Path) to art file. Will use `self.layout.art_file`
+            art_file: Optional path (as str or Path) to art file. Will use `self.art_file`
                 if not provided.
             art_layer: Optional `ArtLayer` where art image should be placed when imported. Will use `self.art_layer`
                 property if not provided.
@@ -778,7 +787,7 @@ class BaseTemplate:
         """
 
         # Set default values
-        art_file = art_file or self.layout.art_file
+        art_file = art_file or self.art_file
         art_layer = art_layer or self.art_layer
         art_reference = art_reference or self.art_reference
 

--- a/src/templates/saga.py
+++ b/src/templates/saga.py
@@ -46,6 +46,7 @@ class SagaMod (NormalTemplate):
     * Layout Checks
     """
 
+    @cached_property
     def is_layout_saga(self) -> bool:
         """Checks whether the card matches SagaLayout."""
         return isinstance(self.layout, SagaLayout)


### PR DESCRIPTION
This does three things:

1. Allow specifying art file via `[art=file.png]` which is utterly useless rn, but required later when I reintroduce automatic panoramas.
2. Add a setting to maintain folder structure, so when picking a file `art/Morrowind/Hlaalu.png` it will be placed in `out/Morrowind/Hlaalu.png` rather than `out/Hlaalu.png`
3. Most importantly adds render-spec support

What is a render-spec?

That's simply a .txt file which contains specification for how to render multiple cards. It's the middle-ground between rendering each card manually and picking "Render All", plus giving some sort-of-programmability. Features in this render-spec are as follows:
- Add named configurations, which are reusable sets of tags, as follows
```
<config name>: (artist) [set] [key=val] ...
```
- Add cards to render in the same format as a filename
- Add groups of objects via putting them into braces, i.e. {} (a object is a card or a group)
- Pipe configurations into an object via | followed by the configuration
- Add a single-line comment, anything followed by #
- All the lines defining a card will be expanded to a single line that defines how to render that card, then some special variables will be expanded:
  - ${GROUP_INDEX}: Expands to the index in the group where the configuration is applied, counting from 0 up by one for each new card
  - ${INNER_GROUP_INDEX}: Same as above
  - ${OUTER_GROUP_INDEX}: Expands to the index in the outer-most group
  
An example render-spec would be this:
```
# Define a named configuration:
#    - render card by the artist "Richard Wright"
#    - with the artwork "Fortress Monastery.jpg"
#    - as a panorama of size 3x1
#    - automatically insert the index in the group as the panorama element index
FortressMonastery: (Richard Wright) [art=Fortress Monastery.jpg] [pano_size=3x1] [pano_elem=${OUTER_GROUP_INDEX}]

{ # Define a group
    { # Define a nested group

        # Render the card "Arcane Signet" with the nickname "Anti-Air Canons"
        Arcane Signet [nick=Anti-Air Canons]

        # Render the card "Command Tower" with the nickname "Fortress Monastery"
        Command Tower [nick=Fortress Monastery]

    # Render this group (i.e. Arcane Signet and Command Tower) from the set 40K
    # This is an inline configuration piped into the group
    } | [40K]

    # Render the card "Mana Severance" with the nickname "Astartes' Last Stand" from the set TMP
    Mana Severance [nick=Astartes' Last Stand] [TMP]
    
# Render this group (i.e. Arcane Signet, Command Tower and Mana Severance) with the configuration FortressMonastery
} | FortressMonastery

# Wildcards are supported too
*.* | [sym=SLD]
Ratadrabik/*.* | [sym=DOM]
```

This example is overkill and also would only work as expected once the panorama code is merged. The PR needs more testing as I only tested the basic features after cherry-picking this stuff for the third time in the last year and a half...

I still wanted to open the PR to see if we can get a discussion going, maybe I am the only one that finds this useful.