### PR TITLE
fix: allow prepare cards to be rendered using adventure layout

### DIFF
--- a/src/enums/mtg.py
+++ b/src/enums/mtg.py
@@ -73,6 +73,7 @@ class LayoutScryfall(StrConstant):
     Class = 'class'
     Saga = 'saga'
     Adventure = 'adventure'
+    Prepare = 'prepare'
     Mutate = 'mutate'
     Prototype = 'prototype'
     Battle = 'battle'

--- a/src/layouts.py
+++ b/src/layouts.py
@@ -1752,6 +1752,7 @@ layout_map: dict[str, Type[CardLayout]] = {
     LayoutScryfall.Class: ClassLayout,
     LayoutScryfall.Saga: SagaLayout,
     LayoutScryfall.Adventure: AdventureLayout,
+    LayoutScryfall.Prepare: AdventureLayout,
     LayoutScryfall.Mutate: MutateLayout,
     LayoutScryfall.Prototype: PrototypeLayout,
     LayoutScryfall.Battle: BattleLayout,


### PR DESCRIPTION
This is a minimal change that allows prepare cards to be rendered. I chose to use the adventure layout because the logic works for prepare cards. Also the existing adventure Photoshop template is serviceable for prepare and omen cards even though it doesn't look right. Omen was already being handled by the adventure layout because Scryfall assigns omen cards the "adventure" layout.

I imagine a more appropriate solution would be new layouts for omen and prepare. However, plugins can still to render cards correctly with this approach by checking for "prepared" in the oracle text and checking for the Omen and Adventure subtypes.